### PR TITLE
fix(CO-986): avoid pgpool connection errors in the kc-dev environments

### DIFF
--- a/carbonio-install/execute-final-setups/templates/pgpool.conf.j2
+++ b/carbonio-install/execute-final-setups/templates/pgpool.conf.j2
@@ -4,7 +4,7 @@ backend_hostname0 = {{ hostvars[groups['postgresServers'][0]].inventory_hostname
 backend_port0 = 5432
 backend_flag0 = 'DISALLOW_TO_FAILOVER'
 
-num_init_children = 32
+num_init_children = 15
 max_pool=8
 reserved_connections=1
 


### PR DESCRIPTION
This a proposal of change to pgpool2 settings, that seems to solve the connection issues we are experiencing on the kc-dev* machines.
The change is decreasing the value of num_init_children from 32 to 15, so that we don't fill the max number of connections (500) on the postgresql instance.
The value is based on this formula:

```
num_init_children * num_mailbox_servers * num_of_databases < 500
```

where:
 * num_init_children = 15
 * num_mailbox_servers = 4 (we have 4 mailbox VMs in the kc-dev* envs)
 * num_of_databases = 7 (we currently have 7 different databases used by different carbonio modules, e.g. core, powerstore, etc.)

```
15 * 4 * 7 = 420
```

This is the reason 15 seems safer than 32.

I am not a pgpool, postgresql or ansible expert, so any better solution is welcome, in particular a more "dynamic" one, where the value is calculated based on the actual mailbox instances on the environment, instead of an hardcoded one.

More information is available in this jira ticket: https://zextras.atlassian.net/browse/CO-986