### PR TITLE
chore: rhel: enable EPEL repo for all servers

### DIFF
--- a/carbonio-install/prepare-carbonio-vms/files/zextras.repo
+++ b/carbonio-install/prepare-carbonio-vms/files/zextras.repo
@@ -1,7 +1,0 @@
-[Zextras]
-name=zextras-carbonio
-baseurl=https://repo.zextras.io/release/rhel8
-enabled=1
-gpgcheck=0
-
-

--- a/carbonio-install/prepare-carbonio-vms/tasks/set-repos.yml
+++ b/carbonio-install/prepare-carbonio-vms/tasks/set-repos.yml
@@ -40,14 +40,19 @@
        - set-repos
 
   - name: Add zextras release repo(RedHat)
-    ansible.builtin.get_url:
-      url: https://repo.zextras.io/release/rhel{{ ansible_distribution_major_version }}/zextras.repo
-      dest: /etc/yum.repos.d/zextras.repo
-      mode: '0644'
-    when: ansible_os_family == "RedHat"
+    ansible.builtin.yum_repository:
+      name: zextras
+      description: Zextras Carbonio Release for RHEL {{ ansible_distribution_major_version }} x86_64 (RPMs)
+      file: zextras
+      baseurl: https://repo.zextras.io/release/rhel{{ ansible_distribution_major_version }}/
+      gpgkey: https://repo.zextras.io/repomd.xml.key
+      gpgcheck: no
+      repo_gpgcheck: no
+      enabled: yes
+    when: ansible_facts['os_family'] == "RedHat"
     tags:
       - set-repos
-  
+
   - name: Update RedHat repo(RedHat)
     become: true
     shell:

--- a/carbonio-install/prepare-carbonio-vms/tasks/set-repos.yml
+++ b/carbonio-install/prepare-carbonio-vms/tasks/set-repos.yml
@@ -32,7 +32,7 @@
   - name: Enable RHEL Postgres repository
     become: true
     ansible.builtin.yum:
-      name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+      name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
       state: present
       disable_gpg_check : true
     when: ansible_os_family == "RedHat" and (inventory_hostname in groups["dbsConnectorServers"] or inventory_hostname in groups["postgresServers"])
@@ -41,7 +41,7 @@
 
   - name: Add zextras release repo(RedHat)
     ansible.builtin.get_url:
-      url: https://repo.zextras.io/release/rhel8/zextras.repo
+      url: https://repo.zextras.io/release/rhel{{ ansible_distribution_major_version }}/zextras.repo
       dest: /etc/yum.repos.d/zextras.repo
       mode: '0644'
     when: ansible_os_family == "RedHat"
@@ -69,8 +69,8 @@
   - name: Enable Epel repo
     become: true
     ansible.builtin.yum:
-      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
       state: present
-    when: ansible_os_family == "RedHat" and inventory_hostname in groups["videoServers"]
+    when: ansible_os_family == "RedHat"
     tags:
        - set-repos    


### PR DESCRIPTION
This will make epel repo available for all the rhel servers (8 & 9 edition), not only on videoserver ones.

The final aim are:
 - make `netcat` (bsd variant only available on epel) installable (24.5.0)
 - make archive decoders (related to @omelyanovich-zextras work on spamassassin upgrade (24.7.0).
