### PR TITLE
ci: register jenkins-lib-common shared library

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>zextras/infra-renovate-config"]
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
     agent {
         node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,12 @@
+library(
+    identifier: 'jenkins-lib-common@v4.10.0',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
+    ])
+)
+
 pipeline {
     agent {
         node {
@@ -9,6 +18,7 @@ pipeline {
         skipDefaultCheckout()
         buildDiscarder(logRotator(numToKeepStr: '10'))
         timeout(time: 1, unit: 'HOURS')
+        disableConcurrentBuilds()
     }
     
     stages {


### PR DESCRIPTION
## Description

Registers `jenkins-lib-common@v4.10.0` as a shared library and adds `disableConcurrentBuilds()` to the pipeline `options`. Part of the consumer-audit tracked in zextras/jenkins-lib-common#189.

No renovate config existed for this repo (no `.github/renovate.json`), so one was added, matching `github>zextras/infra-renovate-config`.

## Changes

- `Jenkinsfile`: add `library(...)` block for `jenkins-lib-common@v4.10.0`, add `disableConcurrentBuilds()`
- `.github/renovate.json`: added (was missing)

## Notes for reviewers

No pipeline stages use `jenkins-lib-common` functions yet — this PR is scoped to registering the library and disabling concurrent builds, per the audit action item.
